### PR TITLE
give flag if either or both si-cloc and si-bandit failed

### DIFF
--- a/aggregators.py
+++ b/aggregators.py
@@ -59,6 +59,14 @@ def sample_aggregator(si_bandit_results: Dict[str, Any], si_cloc_results: Dict[s
 
 def process_data(si_bandit_results: Dict[str, Any], si_cloc_results: Dict[str, Any], **kwargs) -> Dict[str, Any]:
     """Process data into 1 dimensional dict for storing on database."""
+    if si_bandit_results.get("error", False) or si_cloc_results.get("error", False):
+        return {
+            "error": True,
+            "error_messages": {
+                "si_bandit": si_bandit_results.get("error_messages", []),
+                "si_cloc": si_cloc_results.get("error_messages", []),
+            },
+        }
     aggregate_json = security_aggregator.create_si_aggregated_results(
         si_bandit_report=si_bandit_results, si_cloc_report=si_cloc_results, filters_files=["/test"], output_json=True
     )


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/si-bandit/issues/39

## This introduces a breaking change

- [x] Yes
- [ ] No

Graph sync and adviser need to be able to handle a new flag indicating that si failed

## This Pull Request implements

Handles failure cases for si-bandit and si-cloc
